### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/ai_agents/sem_3/requirements.txt
+++ b/ai_agents/sem_3/requirements.txt
@@ -178,7 +178,7 @@ pure_eval==0.2.3
 pyarrow==20.0.0
 pyasn1==0.6.1
 pyasn1_modules==0.4.2
-pyautogen==0.9.0
+ag2==0.9.0
 pybase64==1.4.1
 pycparser==2.22
 pydantic==2.11.7

--- a/ai_agents/sem_4/part_3/agents_autogen.py
+++ b/ai_agents/sem_4/part_3/agents_autogen.py
@@ -18,7 +18,7 @@ try:
     import autogen
     from autogen import ConversableAgent, UserProxyAgent
 except ImportError as e:
-    raise ImportError(f"AutoGen не установлен. Установите: pip install pyautogen. Ошибка: {e}")
+    raise ImportError(f"AutoGen не установлен. Установите: pip install ag2. Ошибка: {e}")
 
 # Конфигурация логирования
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
